### PR TITLE
Fix centerline creation from OpenDRIVE maps with very short lane segments

### DIFF
--- a/omega_prime/locator.py
+++ b/omega_prime/locator.py
@@ -38,7 +38,9 @@ class ShapelyTrajectoryTools:
         if isinstance(l, shapely.Point):
             cl = np.asarray(l.coords)[0]
             return shapely.LineString(np.stack([cl - np.array([0, 1]), cl, cl + np.array([0, 1])]))
-
+        if l.is_empty:
+            cl = np.array([0, 0])
+            return shapely.LineString(np.stack([cl - np.array([0, 1]), cl, cl + np.array([0, 1])]))
         startvec = np.asarray(l.interpolate(0, normalized=True).coords) - np.asarray(
             l.interpolate(0 + cls.epsi, normalized=True).coords
         )

--- a/omega_prime/map_odr.py
+++ b/omega_prime/map_odr.py
@@ -399,6 +399,7 @@ class LaneXodr(Lane):
 
     @classmethod
     def create(cls, lane: PyxodrLane, road: PyxodrRoad, lane_section_id: int, lane_idx: int = None):
+        idx = XodrLaneId(road.id, lane.id, lane_section_id)
         centre_line = getattr(lane, "centre_line", None)
         if centre_line is None or not len(centre_line):
             raise ValueError(f"Lane {lane.id} has no centre_line")
@@ -406,9 +407,11 @@ class LaneXodr(Lane):
         centerline = LineString(centre_line[:, :2])
         if not centerline.is_valid:
             centerline = make_valid(centerline)
+            warnings.warn(
+                f"Needed to make centerline of lane {idx} valid. Most likely, because the OpenDRIVE geometry is translated to a zero length polyline. Try to decrease `step_size`."
+            )
 
         lane_type, lane_subtype = cls._determine_lane_type_and_subtype(lane, road)
-        idx = XodrLaneId(road.id, lane.id, lane_section_id)
         return cls(
             _xodr=lane,
             idx=idx,


### PR DESCRIPTION
For the conversion of OpenDRIVE geometries to polylines we use the library `pyxodr-omega-prime` based on `pyxodr`. These libraries use a fixed step size compute the polylines. During the conversion, for short geometries it can occur that the start and endpoint are the same. This makes the polylines invalid. This pull requests fixes those geometries, so that the `Locator` can work on these maps. Decreasing the `step_size` on map parsing can fix these issues.