### PR TITLE
Use mode instead of median for categorical values role, type, subtype

### DIFF
--- a/omega_prime/recording.py
+++ b/omega_prime/recording.py
@@ -346,7 +346,7 @@ class Recording:
                 self._df.group_by("idx")
                 .agg(
                     pl.col("length", "width", "height").mean(),
-                    pl.col("type", "subtype", "role").median(),
+                    pl.col("type", "subtype", "role").mode().sort().first(),
                     pl.col("frame").min().alias("birth"),
                     pl.col("frame").max().alias("end"),
                     pl.col("total_nanos").min().alias("t_birth"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     'tqdm_joblib',
     'filelock>=3.18.0'
 ]
-version = "0.3.0"
+version = "0.3.1"
 
 [project.urls]
 Homepage = "https://github.com/ika-rwth-aachen/omega-prime"


### PR DESCRIPTION
- type, subtype, and role are categorical values. Therefore the .median() can cause errors in some cases because float values does not make sense
- Use mode instead to get the most frequent one
- in case of same frequency use the smallest number